### PR TITLE
Add PostgreSQL test infrastructure and improve CI/CD pipeline

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+GRADLE_DIST_DIR="$HOME/.gradle/wrapper/dists/gradle-8.11-bin"
+WRAPPER_PROPS="${CLAUDE_PROJECT_DIR}/gradle/wrapper/gradle-wrapper.properties"
+GRADLE_ZIP_URL="https://services.gradle.org/distributions/gradle-8.11-bin.zip"
+
+# Read the expected Gradle version from wrapper properties
+if [ -f "$WRAPPER_PROPS" ]; then
+  EXPECTED_URL=$(grep distributionUrl "$WRAPPER_PROPS" | sed 's/.*=//' | sed 's/\\:/:/g')
+  if [ -n "$EXPECTED_URL" ]; then
+    GRADLE_ZIP_URL="$EXPECTED_URL"
+  fi
+fi
+
+# Check if Gradle wrapper distribution is already available
+GRADLEW="${CLAUDE_PROJECT_DIR}/gradlew"
+if "$GRADLEW" --version >/dev/null 2>&1; then
+  echo "Gradle wrapper already available"
+else
+  echo "Downloading Gradle distribution..."
+  # Find or create the dist subdirectory
+  DIST_SUBDIR=$(find "$GRADLE_DIST_DIR" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | head -1)
+  if [ -z "$DIST_SUBDIR" ]; then
+    DIST_SUBDIR="$GRADLE_DIST_DIR/downloaded"
+    mkdir -p "$DIST_SUBDIR"
+  fi
+
+  ZIP_FILE="$DIST_SUBDIR/gradle-8.11-bin.zip"
+  if [ ! -f "$ZIP_FILE" ] || [ ! -s "$ZIP_FILE" ]; then
+    curl -sL -o "$ZIP_FILE" "$GRADLE_ZIP_URL"
+  fi
+
+  # Unzip if not already done
+  if [ ! -d "$DIST_SUBDIR/gradle-8.11" ]; then
+    cd "$DIST_SUBDIR" && unzip -q gradle-8.11-bin.zip
+  fi
+
+  # Clean up lock files from failed downloads
+  rm -f "$DIST_SUBDIR/gradle-8.11-bin.zip.lck" "$DIST_SUBDIR/gradle-8.11-bin.zip.part"
+fi
+
+# Resolve dependencies (build without tests)
+echo "Resolving project dependencies..."
+cd "$CLAUDE_PROJECT_DIR"
+"$GRADLEW" build -x test --no-daemon 2>&1 || echo "Warning: initial build failed (may need proxy config)"
+
+echo "Session start hook completed"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -45,13 +45,21 @@ jobs:
         run: ./gradlew build -x test
 
       - name: Run tests
-        run: ./gradlew test
+        run: ./gradlew test --stacktrace
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-results
-          path: build/reports/tests/
+          path: |
+            build/reports/tests/
+            build/test-results/test/
+
+      - name: Publish test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: build/test-results/test/*.xml
 
   # Render deployment happens automatically via render.yaml when pushed to master

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -21,6 +21,21 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: testdb
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v4
 
@@ -47,6 +62,11 @@ jobs:
 
       - name: Run tests
         run: ./gradlew test --stacktrace
+        env:
+          QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://localhost:5432/testdb
+          QUARKUS_DATASOURCE_USERNAME: test
+          QUARKUS_DATASOURCE_PASSWORD: test
+          QUARKUS_DATASOURCE_DEVSERVICES_ENABLED: false
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -2,13 +2,14 @@ name: Build Backend
 
 on:
   push:
-    branches: [master]
+    branches: [master, 'claude/**']
     paths:
       - 'src/**'
       - 'build.gradle'
       - 'settings.gradle'
       - 'Dockerfile'
       - 'gradle/**'
+      - '.github/workflows/backend.yml'
   pull_request:
     branches: [master]
     paths:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -2,7 +2,7 @@ name: Build Backend
 
 on:
   push:
-    branches: [master, 'claude/**']
+    branches: [master]
     paths:
       - 'src/**'
       - 'build.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,12 @@ test {
     systemProperty 'java.util.logging.manager', 'org.jboss.logmanager.LogManager'
     systemProperty 'file.encoding', 'UTF-8'
     useJUnitPlatform()
+    testLogging {
+        events 'passed', 'skipped', 'failed', 'standardOut', 'standardError'
+        exceptionFormat 'full'
+        showCauses true
+        showStackTraces true
+    }
 }
 
 jacoco {


### PR DESCRIPTION
## Summary
This PR enhances the backend testing infrastructure by adding a PostgreSQL service to the CI/CD pipeline, improving test execution and reporting, and adding session initialization hooks for development environments.

## Key Changes

- **CI/CD Pipeline Enhancement**
  - Added PostgreSQL 16 Alpine service to GitHub Actions workflow with health checks
  - Configured Quarkus datasource environment variables for test execution
  - Enhanced test task with `--stacktrace` flag for better error diagnostics
  - Added test result publishing via EnricoMi/publish-unit-test-result-action
  - Expanded artifact uploads to include both test reports and XML results

- **Build Configuration**
  - Enhanced Gradle test logging with detailed output including passed/skipped/failed events
  - Added full exception formatting and stack trace visibility for better debugging

- **Development Environment Setup**
  - Added `.claude/settings.json` to configure session start hooks
  - Created `.claude/hooks/session-start.sh` script that:
    - Automatically downloads and caches Gradle distribution
    - Reads expected Gradle version from wrapper properties
    - Resolves project dependencies on session start
    - Provides helpful feedback during initialization

- **Workflow Trigger Updates**
  - Added `.github/workflows/backend.yml` to its own trigger paths to ensure workflow changes are tested

## Implementation Details

The session start hook intelligently manages Gradle distribution caching to avoid redundant downloads while ensuring the correct version is used. The PostgreSQL service is configured with proper health checks to ensure the database is ready before tests execute. Test logging improvements provide comprehensive visibility into test execution for easier debugging and CI/CD troubleshooting.

https://claude.ai/code/session_01SZfE343oxCKWhixdw4ntpX