### PR TITLE
Enable full git history in backend CI workflow

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -47,6 +47,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up GraalVM
         uses: graalvm/setup-graalvm@v1


### PR DESCRIPTION
## Summary
Updated the backend CI workflow to fetch the complete git history during checkout, which is necessary for certain build or analysis tools that require access to commit history.

## Key Changes
- Added `fetch-depth: 0` configuration to the `actions/checkout@v4` step in the backend workflow
  - This ensures the full git history is available instead of the default shallow clone
  - Allows tools that depend on commit history (e.g., version detection, changelog generation) to function correctly

## Implementation Details
The change is minimal and non-breaking - it only affects the checkout behavior in the CI environment by retrieving the complete repository history rather than a shallow clone. This may slightly increase checkout time but enables workflows that require historical commit information.

https://claude.ai/code/session_01XWWMFC5XahwLXfhTxhr3j4