### PR TITLE
fix: remove incorrect "-or" → "-oare" feminine adjective rule

### DIFF
--- a/src/main/kotlin/scrabble/phrases/words/Adjective.kt
+++ b/src/main/kotlin/scrabble/phrases/words/Adjective.kt
@@ -14,7 +14,6 @@ data class Adjective(
         fun computeFeminine(word: String): String = when {
             word.endsWith("esc") -> word.substring(0, word.length - 2) + "ască"
             word.endsWith("eț") -> word.substring(0, word.length - 1) + "ață"
-            word.endsWith("or") -> word.substring(0, word.length - 1) + "are"
             word.endsWith("os") -> word.substring(0, word.length - 1) + "asă"
             word.endsWith("iu") -> word.substring(0, word.length - 1) + "e"
             word.endsWith("ci") -> word.substring(0, word.length - 1) + "e"

--- a/src/test/kotlin/scrabble/phrases/words/AdjectiveTest.kt
+++ b/src/test/kotlin/scrabble/phrases/words/AdjectiveTest.kt
@@ -11,7 +11,7 @@ class AdjectiveTest {
     @CsvSource(
         "pitoresc, pitoreasc\u0103",
         "cite\u021B, citea\u021B\u0103",
-        "bor, boare",
+        "sonor, sonor\u0103",
         "frumos, frumoas\u0103",
         "zglobiu, zglobie",
         "st\u00e2ngaci, st\u00e2ngace",


### PR DESCRIPTION
The computeFeminine() rule for adjectives ending in "-or" was
producing wrong forms (e.g. "insonor" → "insonoare"). In Romanian,
adjectives ending in "-or" (neologisms) form the feminine by adding
"-ă" (e.g. "insonoră", "sonoră", "majoră"). Removing the special
rule lets these fall through to the correct default "else → word + ă".

Replace fabricated test case ("bor"→"boare") with a real adjective
("sonor"→"sonoră").

https://claude.ai/code/session_01PFqN6zn6ExVsWngtNvYfXC