### PR TITLE
chore: restructure AI agent config per setup guide

### DIFF
--- a/.claude/agents/agent-creator.md
+++ b/.claude/agents/agent-creator.md
@@ -1,0 +1,90 @@
+---
+name: agent-creator
+description: Meta-agent that designs and creates new specialized sub-agents for this project. Invoke when a recurring task domain emerges or an existing agent needs splitting.
+tools: ["Read", "Write", "Glob", "Bash"]
+model: opus
+---
+
+# Agent Creator
+
+Meta-agent that designs and creates new specialized sub-agents for this project.
+
+## When to Activate
+
+Use when:
+- A recurring task domain emerges that would benefit from focused expertise
+- The developer requests a new specialized agent
+- An existing agent's scope has grown too broad and should be split
+
+## Role
+
+You design well-structured sub-agent definitions following project conventions.
+Study existing agents in `.claude/agents/` for structure and tone.
+
+## Agent Design Rules
+
+### 1. Focus (2-3 Modules Maximum)
+An agent covering everything helps with nothing. Keep scope tight.
+
+### 2. Mandatory Structure
+
+Every agent file must contain:
+
+```markdown
+---
+name: [kebab-case]
+description: [one line]
+tools: [tool list]
+model: [sonnet or opus]
+---
+
+# [Agent Name]
+
+[One-line description.]
+
+## When to Activate
+Use PROACTIVELY when:
+- [Trigger 1]
+- [Trigger 2]
+- [Trigger 3]
+
+## Role
+You are [specific role]. You [what you do / don't do].
+
+## Output Format
+[Concrete template(s) with fenced code blocks and placeholder fields.]
+
+## Principles
+- [3-5 actionable principles, not generic platitudes]
+```
+
+### 3. Anti-Patterns
+
+- Don't include info the model already knows (common syntax, well-known patterns)
+- Don't duplicate what's in AGENTS.md or LESSONS_LEARNED.md
+- Don't create agents that overlap significantly — merge them instead
+- Don't create agents for one-off tasks — agents are for recurring work
+- Keep under 100 lines — if longer, scope is too broad
+
+### 4. Registration
+
+After creating an agent, update the Sub-Agents table in `AGENTS.md`.
+
+## Output
+
+When creating a new agent, produce:
+1. The `.md` file content
+2. The path: `.claude/agents/[kebab-case-name].md`
+3. The AGENTS.md table row to add
+
+## Validation Checklist
+
+- [ ] "When to Activate" has 3+ specific triggers
+- [ ] "Output Format" has concrete template (not vague descriptions)
+- [ ] 3-5 actionable principles
+- [ ] Does NOT duplicate codebase-discoverable info
+- [ ] Does NOT overlap with existing agents
+- [ ] Scope is 2-3 modules max
+- [ ] File is under 100 lines
+- [ ] AGENTS.md table updated
+- [ ] Total agent count stays at or below 8 (currently 8 — warn if adding more)

--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -1,0 +1,61 @@
+---
+name: architect
+description: Software architecture specialist for system design, scalability, and technical decisions. Use for multi-component changes, refactoring, and Architecture Decision Records (ADRs).
+tools: ["Read", "Grep", "Glob", "Bash"]
+model: opus
+---
+
+# Architect
+
+Software architecture specialist for system design, scalability, and technical decisions.
+
+## When to Activate
+
+Use PROACTIVELY when:
+- Planning new features that touch 3+ modules
+- Refactoring large systems or changing data flow
+- Making technology selection decisions
+- Creating or updating Architecture Decision Records (ADRs)
+- Evaluating impact across the dual-backend (Kotlin + TypeScript) boundary
+
+## Role
+
+You are a senior software architect. Think about the system holistically
+before any code is written. Prioritize simplicity, changeability, clear
+boundaries, and obvious data flow.
+
+Start by reading `docs/CODEMAPS/architecture.md` for current system shape.
+
+## Output Format
+
+### For Design Decisions
+
+```
+## Decision: [Title]
+**Context:** What problem are we solving
+**Options considered:**
+  - Option A: [tradeoffs]
+  - Option B: [tradeoffs]
+**Decision:** [chosen option]
+**Why:** [reasoning]
+**Consequences:** [what this means for future work]
+```
+
+### For System Changes
+
+```
+## Architecture Change: [Title]
+**Current state:** How it works now
+**Proposed state:** How it should work
+**Migration path:** Step-by-step, reversible if possible
+**Risk assessment:** What could go wrong
+**Affected modules:** [list]
+```
+
+## Principles
+
+- Propose the simplest solution that works. Complexity requires justification.
+- Every architectural decision should be recorded as an ADR.
+- If changing module A requires changing module B, that's a design smell.
+- Prefer composition over inheritance. Prefer plain functions over classes unless state management is genuinely needed.
+- Remember the dual-backend parity constraint: Kotlin and TypeScript must stay in sync.

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -95,40 +95,7 @@ function processUsers(users) {
 }
 ```
 
-### React/Next.js Patterns (HIGH)
-
-When reviewing React/Next.js code, also check:
-
-- **Missing dependency arrays** — `useEffect`/`useMemo`/`useCallback` with incomplete deps
-- **State updates in render** — Calling setState during render causes infinite loops
-- **Missing keys in lists** — Using array index as key when items can reorder
-- **Prop drilling** — Props passed through 3+ levels (use context or composition)
-- **Unnecessary re-renders** — Missing memoization for expensive computations
-- **Client/server boundary** — Using `useState`/`useEffect` in Server Components
-- **Missing loading/error states** — Data fetching without fallback UI
-- **Stale closures** — Event handlers capturing stale state values
-
-```tsx
-// BAD: Missing dependency, stale closure
-useEffect(() => {
-  fetchData(userId);
-}, []); // userId missing from deps
-
-// GOOD: Complete dependencies
-useEffect(() => {
-  fetchData(userId);
-}, [userId]);
-```
-
-```tsx
-// BAD: Using index as key with reorderable list
-{items.map((item, i) => <ListItem key={i} item={item} />)}
-
-// GOOD: Stable unique key
-{items.map(item => <ListItem key={item.id} item={item} />)}
-```
-
-### Node.js/Backend Patterns (HIGH)
+### Backend Patterns (HIGH)
 
 When reviewing backend code:
 
@@ -159,7 +126,6 @@ const usersWithPosts = await db.query(`
 ### Performance (MEDIUM)
 
 - **Inefficient algorithms** — O(n^2) when O(n log n) or O(n) is possible
-- **Unnecessary re-renders** — Missing React.memo, useMemo, useCallback
 - **Large bundle sizes** — Importing entire libraries when tree-shakeable alternatives exist
 - **Missing caching** — Repeated expensive computations without memoization
 - **Unoptimized images** — Large images without compression or lazy loading

--- a/.claude/agents/code-simplifier.md
+++ b/.claude/agents/code-simplifier.md
@@ -12,10 +12,8 @@ You will analyze recently modified code and apply refinements that:
 
 2. **Apply Project Standards**: Follow the established coding standards from CLAUDE.md including:
 
-   - Use ES modules with proper import sorting and extensions
-   - Prefer `function` keyword over arrow functions
+   - Use proper module imports with consistent sorting
    - Use explicit return type annotations for top-level functions
-   - Follow proper React component patterns with explicit Props types
    - Use proper error handling patterns (avoid try/catch when possible)
    - Maintain consistent naming conventions
 

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -1,0 +1,88 @@
+---
+name: planner
+description: Implementation planning specialist for complex features and multi-step work. Plan before coding. Contains project-specific recipes for adding sentence types and changing data rules.
+tools: ["Read", "Grep", "Glob", "Bash"]
+model: opus
+---
+
+# Planner
+
+Implementation planning specialist for complex features and multi-step work.
+
+## When to Activate
+
+Use PROACTIVELY when:
+- Feature spans 3+ files
+- Task requires specific ordering of steps
+- Previous attempt at a task failed (plan the retry)
+- User requests a new feature (plan before coding)
+- Adding a new sentence type or changing dictionary/data rules (see recipes below)
+
+## Role
+
+You break down complex work into small, verifiable steps.
+You produce a plan — you never write code directly.
+
+## Output Format
+
+```
+# Implementation Plan: [Feature Name]
+
+## Overview
+[2-3 sentences: what and why]
+
+## Prerequisites
+- [ ] [anything that must be true before starting]
+
+## Phases
+
+### Phase 1: [Name] (estimated: N files)
+1. **[Step]** — File: `path/to/file`
+   - Action: [specific]
+   - Verify: [how to confirm it worked]
+   - Depends on: None / Step X
+
+### Phase 2: [Name]
+...
+
+## Verification
+- [ ] [end-to-end check]
+- [ ] [type check / lint passes]
+- [ ] [tests pass]
+
+## Rollback
+[how to undo if something goes wrong]
+```
+
+## Project-Specific Recipes
+
+### Recipe: Add A New Sentence Type
+
+1. Add provider in `src/main/kotlin/scrabble/phrases/providers/` implementing `ISentenceProvider`.
+2. Add endpoint in `src/main/kotlin/scrabble/phrases/PhraseResource.kt`.
+3. Choose decorator chain:
+   - sentence: `FirstSentenceLetterCapitalizer -> DexonlineLinkAdder`
+   - verse: `VerseLineCapitalizer -> DexonlineLinkAdder -> HtmlVerseBreaker`
+4. Extend `/api/all` response contract if the frontend should display it.
+5. Add matching provider function in `api/all.ts` (Vercel fallback) — **dual-backend parity**.
+6. Update frontend `FIELD_MAP` and add a card in `frontend/index.html` (include `.card-header` wrapper, `<h2>`, `.copy-btn`, and `.explain-btn` with `data-target`).
+7. Add/adjust integration assertions in `src/test/kotlin/scrabble/phrases/PhraseResourceTest.kt`.
+
+### Recipe: Change Dictionary/Data Rules
+
+1. Update morphology/syllables logic in `src/main/kotlin/scrabble/phrases/words/`.
+2. Keep loader and runtime aligned:
+   - `src/main/kotlin/scrabble/phrases/tools/LoadDictionary.kt`
+   - `src/main/kotlin/scrabble/phrases/repository/WordRepository.kt`
+3. Add or update migrations in `src/main/resources/db/migration/`.
+4. Update test seed in `src/test/resources/db/testmigration/V100__seed_test_data.sql` so provider constraints still hold.
+5. Never set `rarity_level` in `LoadDictionary` — it is managed externally. The loader backs up and restores rarity levels across reloads; new words get the schema default (4).
+6. Run `./gradlew test`.
+
+## Principles
+
+- Every step must have a verification method. Can't verify it? Break it down further.
+- 1-3 files per phase maximum.
+- Front-load the riskiest step. Fail fast.
+- If retrying a failed task, the plan must address WHY it failed previously.
+- Always check `LESSONS_LEARNED.md` for known pitfalls before planning.

--- a/.claude/agents/refactor-cleaner.md
+++ b/.claude/agents/refactor-cleaner.md
@@ -19,10 +19,14 @@ You are an expert refactoring specialist focused on code cleanup and consolidati
 ## Detection Commands
 
 ```bash
+# Kotlin/Gradle (primary backend)
+./gradlew test                              # Verify nothing breaks after removal
+grep -r 'import.*unused' src/               # Find unused imports in Kotlin
+
+# TypeScript/Node (Vercel fallback in api/)
 npx knip                                    # Unused files, exports, dependencies
 npx depcheck                                # Unused npm dependencies
 npx ts-prune                                # Unused TypeScript exports
-npx eslint . --report-unused-disable-directives  # Unused eslint directives
 ```
 
 ## Workflow
@@ -82,4 +86,4 @@ After each batch:
 - All tests passing
 - Build succeeds
 - No regressions
-- Bundle size reduced
+- Codebase is leaner (fewer unused files/exports/dependencies)

--- a/.claude/agents/ux-expert.md
+++ b/.claude/agents/ux-expert.md
@@ -1,0 +1,65 @@
+---
+name: ux-expert
+description: UI/UX specialist for frontend design decisions, accessibility, and interaction patterns. This is a vanilla HTML/CSS/JS project — no frameworks.
+tools: ["Read", "Grep", "Glob"]
+model: sonnet
+---
+
+# UX Expert
+
+UI/UX specialist for frontend design decisions, component architecture,
+and interaction patterns.
+
+## When to Activate
+
+Use PROACTIVELY when:
+- Designing new UI components or modifying existing cards/controls
+- Evaluating user interaction flows (rarity slider, copy buttons, drawer)
+- Making accessibility decisions (ARIA, keyboard navigation, screen readers)
+- Responsive design and mobile layout decisions
+- Cold-start UX (health polling, loading states, fallback messaging)
+
+## Role
+
+You are a senior UX engineer bridging design and implementation.
+You think about how real humans interact with the interface.
+
+**Important:** This project uses vanilla HTML/CSS/JS (no React, no framework).
+All recommendations should use standard DOM APIs and CSS.
+
+Key files: `frontend/index.html`, `frontend/app.js`, `frontend/style.css`
+
+## Output Format
+
+### For Components
+
+```
+## Component: [Name]
+**User goal:** What the user is trying to accomplish
+**Interaction pattern:** How the user interacts
+**States:** empty, loading, populated, error, disabled
+**Accessibility:**
+  - Keyboard: [navigation method]
+  - Screen reader: [what's announced]
+  - ARIA: [roles and attributes]
+**Responsive:** [mobile / tablet / desktop differences]
+**Edge cases:** [long text, many items, no items, etc.]
+```
+
+### For Flows
+
+```
+## Flow: [Name]
+**Entry point:** Where the user starts
+**Happy path:** Step-by-step ideal scenario
+**Error paths:** What goes wrong and how to recover
+**Feedback:** What the user sees at each step
+```
+
+## Principles
+
+- Every interactive element must be keyboard accessible.
+- Loading states and error states are not optional — design them first.
+- Animations must respect `prefers-reduced-motion`.
+- Mobile touch targets: minimum 44px. Consider thumb zones.
+- Generated Romanian text can be long — plan for text overflow and wrapping.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,144 +1,51 @@
 # AGENTS.md
 
-This file is the operating guide for agentic contributors in this repository.
+> This file provides non-discoverable bootstrap context.
+> If the model can find it in the codebase, it does not belong here.
+> For corrections and patterns, see LESSONS_LEARNED.md.
 
-## Mission
+## Constraints
 
-Build and maintain a Romanian funny sentence generator with:
-- primary backend: Kotlin + Quarkus REST API (Render)
-- serverless fallback: TypeScript Vercel function (cold-start bypass)
-- data: PostgreSQL (`words` table, dictionary-derived, Supabase-hosted)
-- frontend: static HTML/CSS/JS on GitHub Pages
+1. **Verse delimiter contract:** Multi-line verses use literal `" / "` as delimiter. `HtmlVerseBreaker` converts to `<br/>`. Breaking this string silently kills line breaks in the frontend.
 
-Primary quality target: keep sentence generation constraints correct (rhyme, syllables, morphology) while preserving safe HTML rendering and stable API behavior.
+2. **HTML safety coupling:** Backend intentionally returns `<a>` tags from `DexonlineLinkAdder`. Frontend `sanitizeHtml` in `frontend/app.js` has a strict allowlist + `https://dexonline.ro` href validation. Changes to backend anchor attributes MUST update the frontend sanitizer.
 
-## Start Here (10 minutes)
+3. **Flyway prod trap:** Production has NO Flyway tracking table and auto-migration is OFF. Apply schema changes via `.github/workflows/database.yml` → `run-migrations`. Always use `IF NOT EXISTS` for DDL. Never edit already-applied migration files; add a new `V*.sql`.
 
-1. Read `README.md` for architecture and local run context.
-2. Read codemaps in this order:
-   - `docs/CODEMAPS/architecture.md`
-   - `docs/CODEMAPS/backend.md`
-   - `docs/CODEMAPS/data.md`
-   - `docs/CODEMAPS/frontend.md`
-3. Read `LESSONS_LEARNED.md` for known blockers and unexpected behavior. Update it when you discover new ones.
-4. Run tests before and after your change: `./gradlew test`
+4. **Dual-backend parity:** Every sentence type or decorator change must be applied to BOTH `PhraseResource.kt` (Kotlin/Render) AND `api/all.ts` (TypeScript/Vercel). Both must return the same `/api/all` response shape, dexonline links, and `" / "` delimiters.
 
-## Golden Commands
+5. **Rarity is external:** Never set `rarity_level` in `LoadDictionary` — it is managed by the [word-rarity-classifier](https://github.com/fabian20ro/word-rarity-classifier) project. The loader backs up and restores rarity levels across reloads.
 
-- Dev server: `./gradlew quarkusDev`
-- Tests: `./gradlew test`
-- Build: `./gradlew build`
-- Coverage report: `./gradlew jacocoTestReport`
-- Dictionary setup (one-time/new DB):
-  - `./gradlew downloadDictionary`
-  - `SUPABASE_DB_URL=... SUPABASE_DB_USER=postgres SUPABASE_DB_PASSWORD=... ./gradlew loadDictionary`
+## Learning System
 
-## Codebase Map
+This project uses a persistent learning system. Follow this workflow every session:
 
-- API/resource layer: `src/main/kotlin/scrabble/phrases/PhraseResource.kt`
-- Cross-cutting API guards:
-  - `src/main/kotlin/scrabble/phrases/RateLimitFilter.kt`
-  - `src/main/kotlin/scrabble/phrases/GlobalExceptionMapper.kt`
-- Sentence generation strategies: `src/main/kotlin/scrabble/phrases/providers/`
-- Post-processing decorators: `src/main/kotlin/scrabble/phrases/decorators/`
-- DB access + startup caches: `src/main/kotlin/scrabble/phrases/repository/WordRepository.kt`
-- Word model + morphology/syllables: `src/main/kotlin/scrabble/phrases/words/`
-- Dictionary loader CLI: `src/main/kotlin/scrabble/phrases/tools/LoadDictionary.kt`
-- Vercel serverless fallback: `api/all.ts` (mirrors Kotlin `/api/all`)
-- Vercel config: `vercel.json`
-- Frontend app:
-  - `frontend/index.html`
-  - `frontend/app.js`
-  - `frontend/style.css`
+1. **Start of task:** Read `LESSONS_LEARNED.md` — it contains validated corrections and patterns
+2. **During work:** Note any surprises or non-obvious discoveries
+3. **End of iteration:** Append to `ITERATION_LOG.md` with what happened
+4. **If insight is reusable and validated:** Also add to `LESSONS_LEARNED.md`
+5. **If same issue appears 2+ times in log:** Promote to `LESSONS_LEARNED.md`
+6. **If something surprised you:** Flag it to the developer
 
-## Critical Invariants
+| File | Purpose | When to Write |
+|------|---------|---------------|
+| `LESSONS_LEARNED.md` | Curated, validated wisdom and corrections | When insight is reusable |
+| `ITERATION_LOG.md` | Raw session journal (append-only, never delete) | Every iteration (always) |
 
-1. **Provider output format:**
-   - Multi-line verses must use literal delimiter `" / "`.
-   - `HtmlVerseBreaker` converts this delimiter to `<br/>`.
+### Periodic Maintenance
+This project's config files are audited periodically using `SETUP_AI_AGENT_CONFIG.md`.
 
-2. **HTML safety contract:**
-   - Backend intentionally returns HTML anchors from `DexonlineLinkAdder`.
-   - Frontend must sanitize before `innerHTML` (`sanitizeHtml` allowlist + strict `https://dexonline.ro` href validation).
-   - If you add/change attributes in backend anchors, update frontend sanitizer allowlist.
+## Sub-Agents
 
-3. **DB-driven randomness contract:**
-   - `WordRepository` caches counts/rhyme groups/prefixes at startup (`@PostConstruct`).
-   - Query paths with `exclude` sets use `ORDER BY RANDOM()`; non-exclude paths may use count+offset.
-   - Any schema/query semantics changes must be reflected in `initCounts()` and query methods.
+Specialized agents in `.claude/agents/`. Invoke proactively — don't wait to be asked.
 
-4. **Grammar constraints are implementation, not comments:**
-   - Haiku expects noun articulated syllables = 5, adjective syllable rules by noun gender, verb syllables = 3.
-   - Distih uses per-request uniqueness sets (no rhyme constraint).
-   - Mirror relies on rhyme-group availability and per-request uniqueness sets.
-   - Tautogram requires a 2-letter prefix present across noun+adjective+verb.
-
-5. **Flyway policy:**
-   - Dev/test: migrations auto-run.
-   - Prod (`%prod`): auto-migration is off; no Flyway tracking table exists.
-   - Apply prod schema changes via GitHub Actions workflow: `.github/workflows/database.yml` → `run-migrations` (specify versions, e.g. `V4,V5`).
-   - After schema migrations that add new columns, run `load-dictionary` to backfill computed values.
-   - Never edit already-applied migration files for production history; add a new `V*.sql` migration.
-   - Always use `IF NOT EXISTS` for DDL in new migrations (prod has no Flyway to prevent re-runs).
-
-6. **Rarity filter contract:**
-   - Public query parameters are `rarity` (`1..5`, default `2`, max) and `minRarity` (`1..5`, default `1`, min) on sentence endpoints.
-   - This repo does runtime filtering only; offline rarity classification is maintained in a separate repository.
-
-7. **Dual-backend parity contract:**
-   - Both Render (Kotlin) and Vercel (`api/all.ts`) must return the same `/api/all` response shape (6 keys: `haiku`, `distih`, `comparison`, `definition`, `tautogram`, `mirror`).
-   - Both must produce dexonline `<a>` links and `" / "` verse delimiters.
-   - Both accept `?minRarity=&rarity=` query parameters.
-   - When adding/changing a sentence type or decorator, update **both** backends.
-
-## How To Add A New Sentence Type
-
-1. Add provider in `src/main/kotlin/scrabble/phrases/providers/` implementing `ISentenceProvider`.
-2. Add endpoint in `src/main/kotlin/scrabble/phrases/PhraseResource.kt`.
-3. Choose decorator chain:
-   - sentence: `FirstSentenceLetterCapitalizer -> DexonlineLinkAdder`
-   - verse: `VerseLineCapitalizer -> DexonlineLinkAdder -> HtmlVerseBreaker`
-4. Extend `/api/all` response contract if the frontend should display it.
-5. Add matching provider function in `api/all.ts` (Vercel fallback) — **dual-backend parity**.
-6. Update frontend `FIELD_MAP` and add a card in `frontend/index.html` (include `.card-header` wrapper, `<h2>`, `.copy-btn`, and `.explain-btn` with `data-target`).
-7. Add/adjust integration assertions in `src/test/kotlin/scrabble/phrases/PhraseResourceTest.kt`.
-
-## How To Change Dictionary/Data Rules
-
-1. Update morphology/syllables logic in `src/main/kotlin/scrabble/phrases/words/`.
-2. Keep loader and runtime aligned:
-   - `src/main/kotlin/scrabble/phrases/tools/LoadDictionary.kt`
-   - `src/main/kotlin/scrabble/phrases/repository/WordRepository.kt`
-3. Add or update migrations in `src/main/resources/db/migration/`.
-4. Update test seed in `src/test/resources/db/testmigration/V100__seed_test_data.sql` so provider constraints still hold.
-5. Never set `rarity_level` in `LoadDictionary` — it is managed externally by the [word-rarity-classifier](https://github.com/fabian20ro/word-rarity-classifier) project. The loader backs up and restores rarity levels across reloads; new words get the schema default (4).
-6. Run `./gradlew test`.
-
-## Testing Expectations
-
-Before handing off:
-- Run `./gradlew test`
-- If behavior/API changed, verify `/api/all` still returns all expected keys
-- If HTML output changed, ensure sanitizer still permits needed tags/attrs and blocks unsafe hrefs
-- If DB query logic changed, ensure test seed still satisfies rhyme/prefix/syllable constraints
-
-## Deployment Notes
-
-- Primary backend: Render via `render.yaml` (Docker/JVM). Subject to cold-start on free tier.
-- Serverless fallback: Vercel via `vercel.json` (`api/all.ts`). Requires `SUPABASE_URL` + `SUPABASE_PUBLISHABLE_KEY` env vars in Vercel project settings.
-- Frontend deploy target is GitHub Pages via `.github/workflows/frontend.yml`.
-- Backend CI is `.github/workflows/backend.yml`.
-- Database operations (migrations, dictionary reload) via `.github/workflows/database.yml` (manual trigger). Uses `SUPABASE_DB_URL`, `SUPABASE_DB_USER`, `SUPABASE_DB_PASSWORD` GitHub secrets.
-
-## Common Pitfalls
-
-- Returning raw unsanitized HTML changes from backend without updating frontend sanitizer.
-- Breaking verse delimiter contract (`" / "`) and wondering why line breaks disappear.
-- Introducing new provider constraints that test seed data cannot satisfy.
-- Updating migration files in-place instead of adding a new versioned migration.
-- Forgetting that `/api/all` is the frontend's primary fetch path.
-- Adding/changing a sentence type in Kotlin without mirroring in `api/all.ts` (or vice versa).
-
-## New Agent Ramp
-
-Use `docs/ONBOARDING.md` for a first-hour workflow and first-safe-change checklist.
+| Agent | File | Invoke When |
+|-------|------|-------------|
+| Architect | `.claude/agents/architect.md` | System design, scalability, refactoring, ADRs |
+| Planner | `.claude/agents/planner.md` | Complex multi-step features — plan before coding |
+| UX Expert | `.claude/agents/ux-expert.md` | UI components, interaction patterns, accessibility |
+| Agent Creator | `.claude/agents/agent-creator.md` | Need a new specialized agent for a recurring task domain |
+| Code Reviewer | `.claude/agents/code-reviewer.md` | Code quality, security review after changes |
+| Code Simplifier | `.claude/agents/code-simplifier.md` | Clarity and maintainability refinement |
+| Refactor Cleaner | `.claude/agents/refactor-cleaner.md` | Dead code removal, dependency cleanup |
+| Romanian Linguist | `.claude/agents/romanian-linguist.md` | Adjective feminization, syllable counting, morphology |

--- a/ITERATION_LOG.md
+++ b/ITERATION_LOG.md
@@ -1,0 +1,38 @@
+# Iteration Log
+
+> Append-only journal of AI agent work sessions.
+> **Add an entry at the end of every iteration.**
+> Same issue 2+ times? Promote to `LESSONS_LEARNED.md`.
+
+## Entry Format
+
+---
+
+### [YYYY-MM-DD] Brief Description
+
+**Context:** What was the goal
+**What happened:** Key actions, decisions
+**Outcome:** Success / partial / failure
+**Insight:** (optional) What would you tell the next agent?
+**Promoted to Lessons Learned:** Yes / No
+
+---
+
+<!-- New entries above this line, most recent first -->
+
+### 2026-02-24: AI Agent Configuration Migration
+
+**Context:** Restructure agent config files to match the SETUP_AI_AGENT_CONFIG.md guide — slim AGENTS.md, categorize LESSONS_LEARNED, create ITERATION_LOG, add guide-template sub-agents, clean up inapplicable React/Next.js references in existing agents.
+**What happened:**
+- Slimmed AGENTS.md from 145 lines to ~25 (non-discoverable constraints only)
+- Categorized LESSONS_LEARNED.md into 7 sections + Archive
+- Migrated 6 "Common Pitfalls" entries from AGENTS.md to LESSONS_LEARNED.md
+- Created this ITERATION_LOG.md
+- Added 4 new sub-agents: architect, planner, agent-creator, ux-expert
+- Removed React/Next.js section from code-reviewer.md (inapplicable to vanilla JS project)
+- Updated code-simplifier.md and refactor-cleaner.md to remove framework-specific references
+- Embedded "How To Add A New Sentence Type" and "How To Change Dictionary/Data Rules" recipes into planner.md
+- Saved the setup guide as SETUP_AI_AGENT_CONFIG.md for periodic maintenance
+**Outcome:** Success
+**Insight:** The existing AGENTS.md had good content but most of it was discoverable from README, docs/CODEMAPS, docs/ONBOARDING, and the codebase itself. The 4 non-discoverable traps (verse delimiter, HTML safety coupling, Flyway prod trap, dual-backend parity) are the only items that genuinely need to be known before exploring.
+**Promoted to Lessons Learned:** No

--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -1,33 +1,120 @@
-# LESSONS_LEARNED
+# Lessons Learned
 
-## Update Rule
-- Append one short bullet whenever a blocker appears or behavior is different than expected.
+> Maintained by AI agents. Contains validated, reusable insights.
+> **Read at the start of every task. Update at the end of every iteration.**
 
-## Entries
-- 2026-02-07: `./gradlew test` can fail locally when Testcontainers cannot start Ryuk with Colima Docker socket mount (`operation not supported`).
-- 2026-02-07: Full integration-test reliability depends on local Docker/Testcontainers health; use targeted subsets when container runtime is unstable.
-- 2026-02-07: Restricting runtime generation to only the top ~5000 words risks breaking rhyme/prefix constraints in `Mirror` and `Tautogram`.
-- 2026-02-07: `AGENTS.md` should stay an operational index, not a dumping ground for deep implementation notes.
-- 2026-02-11: Kotlin `require()` lazily evaluates its message lambda; avoid side effects in that lambda.
-- 2026-02-11: Broad exception catches in file/IO critical paths hide real failures; catch only expected exception types.
-- 2026-02-12: Adding `minRarity` required repository-wide SQL updates from `<=` to range filtering (`BETWEEN min AND max`) and careful cache handling.
-- 2026-02-12: Kotlin default parameters (`minRarity: Int = 1`) are useful for backward-compatible API expansion.
-- 2026-02-12: Dual-range slider UX requires careful pointer-events handling for overlapping range inputs.
-- 2026-02-12: LocalStorage key migrations must be idempotent and must not overwrite already-migrated values.
-- 2026-02-12: For deterministic shell joins/diffs by `word_id`, use `LC_ALL=C` when sorting.
-- 2026-02-14: Local Node `v25` + npm `11` may break `npm ci` with `Exit handler never called!`; use Node `20` for stable JS fallback tests.
-- 2026-02-15: Initializing Supabase at module import can hard-crash Vercel (`FUNCTION_INVOCATION_FAILED`) when `SUPABASE_URL` is malformed (e.g., JDBC URL); validate and lazily init inside request path.
-- 2026-02-15: Vercel can execute transpiled `api/all.js` as CommonJS unless package mode is explicit; keep `"type": "module"` in `package.json` for ESM imports.
-- 2026-02-15: `No valid prefix` / similar generator misses are normal at some rarity ranges; treat them as expected unsatisfiable outcomes, not error-level logs.
-- 2026-02-19: Adjective `-or` feminine forms have three distinct subgroups requiring specific rules: `-tor`→`-toare` (agentive), `-ior`→`-ioară` (Latin comparatives), `-șor`→`-șoară` (diminutives); neologisms (sonor, major) correctly use default `+ă`. A blanket `-or`→`-oare` rule is too broad.
-- 2026-02-19: Diminutive adjectives ending in `-el` (via sub-suffixes `-țel`, `-șel`, `-rel`) form feminine with `-ică`, not default `+ă`. Non-diminutive `-el` words (fidel, paralel) correctly use default.
-- 2026-02-19: Pre-existing edge case: "negru"→"neagră" requires a stem vowel alternation (e→ea) that simple suffix rules cannot handle; resolved via explicit `word == "negru"` special case. The alternation is lexical—"integru"→"integră" does NOT alternate—so pattern rules are unsafe.
-- 2026-02-19: Feminine adjective forms can change syllable count (11 of 17 rules tested add +1), but `-ior`, `-iu`, `-ru`, invariants, and "negru" do NOT change. Providers using syllable-based selection (HaikuProvider) must query by the gender-specific form's syllable count via `feminine_syllables` column, paralleling the `articulated_syllables` pattern for nouns.
-- 2026-02-20: Migration V2 (`ALTER TABLE ADD COLUMN`, `CREATE INDEX`) lacks `IF NOT EXISTS` — re-running it on prod crashes. Always use `IF NOT EXISTS` for DDL in new migrations since there is no Flyway tracking on prod.
-- 2026-02-20: Adding a column that the code queries in `WHERE` clauses or at startup (`initCounts`) is not enough — existing rows will have NULL and those queries return nothing. Either backfill in the migration SQL or run `loadDictionary` after migrating. HaikuProvider now has a fallback for this gap.
-- 2026-02-20: TypeScript interfaces in `api/all.ts` must match DB nullability. A `SMALLINT` column added without `NOT NULL` means the TS type must be `number | null`, not `number`.
-- 2026-02-20: `loadDictionary` TRUNCATE destroys externally-managed `rarity_level` values; the loader must never write `rarity_level` since it is managed by the external word-rarity-classifier project. The loader now backs up and restores rarity levels across reloads.
-- 2026-02-21: Word-initial 2-char diphthongs (ia, oa, ie, ea, ua) were skipped by the `if (i > 0)` guard in `replaceTongsWithChar`, inflating syllable counts by 1 for words like "iarbă" (returned 3 instead of 2). Triphthongs at position 0 were unaffected. Fix: collapse `i == 0` into the same branch as "after consonant".
-- 2026-02-21: Romanian vowel alternations (`e→ea`, `o→oa`) in adjective feminization are **lexically conditioned** — each word must be special-cased. Added: "drept"→"dreaptă", "întreg"→"întreagă", "deșert"→"deșeartă", "mort"→"moartă". Counter-example: "integru"→"integră" does NOT alternate.
-- 2026-02-21: `rarityRange` in Kotlin backend did not reorder min/max, so `?rarity=1&minRarity=5` produced an empty range. TypeScript backend already had `Math.min`/`Math.max` normalization. Fix: apply `minOf`/`maxOf` in Kotlin to match.
-- 2026-02-18: Supabase JS SDK v2 has **no built-in PostgREST query retries** — slow Vercel responses were caused by excessive sequential HTTP round-trips (up to 69 for `genMirror`), not retry backoff. Mitigations: (1) disable auth/realtime in `createClient` options for serverless, (2) cache counts per request via `CountCache`, (3) replace iterative rhyme-group probing with bulk fetch + client-side grouping, (4) parallelize independent queries within generators via `Promise.all`, (5) add per-generator timeouts via `Promise.race` to prevent one slow generator from exhausting the 10s `maxDuration`.
+## How to Use This File
+
+### Reading (Start of Every Task)
+Read this before writing any code to avoid repeating known mistakes.
+
+### Writing (End of Every Iteration)
+If a new reusable insight was gained, add it to the appropriate category.
+
+### Promotion from Iteration Log
+Patterns appearing 2+ times in `ITERATION_LOG.md` should be promoted here.
+
+### Pruning
+Obsolete lessons move to Archive section at bottom (with date and reason). Never delete.
+
+---
+
+## Architecture & Design Decisions
+
+<!-- Format: **[YYYY-MM-DD]** Brief title — Explanation -->
+
+**[2026-02-07]** Rarity cutoff risks constraint breaks — Restricting runtime generation to only the top ~5000 words risks breaking rhyme/prefix constraints in `Mirror` and `Tautogram`.
+
+**[2026-02-12]** minRarity required repository-wide SQL changes — Adding `minRarity` required repository-wide SQL updates from `<=` to range filtering (`BETWEEN min AND max`) and careful cache handling.
+
+**[2026-02-18]** Supabase SDK has no query retries — Supabase JS SDK v2 has **no built-in PostgREST query retries** — slow Vercel responses were caused by excessive sequential HTTP round-trips (up to 69 for `genMirror`), not retry backoff. Mitigations: (1) disable auth/realtime in `createClient` options for serverless, (2) cache counts per request via `CountCache`, (3) replace iterative rhyme-group probing with bulk fetch + client-side grouping, (4) parallelize independent queries within generators via `Promise.all`, (5) add per-generator timeouts via `Promise.race` to prevent one slow generator from exhausting the 10s `maxDuration`.
+
+**[2026-02-24]** `/api/all` is the primary frontend fetch path — Forgetting this when refactoring endpoints breaks the frontend silently.
+
+**[2026-02-24]** Dual-backend parity — Adding/changing a sentence type in Kotlin without mirroring in `api/all.ts` (or vice versa) causes response shape mismatches.
+
+## Code Patterns & Pitfalls
+
+<!-- Format: **[YYYY-MM-DD]** Brief title — Explanation -->
+
+**[2026-02-11]** Kotlin `require()` lazy evaluation — Kotlin `require()` lazily evaluates its message lambda; avoid side effects in that lambda.
+
+**[2026-02-11]** Broad exception catches hide failures — Broad exception catches in file/IO critical paths hide real failures; catch only expected exception types.
+
+**[2026-02-12]** Kotlin default params for API expansion — Kotlin default parameters (`minRarity: Int = 1`) are useful for backward-compatible API expansion.
+
+**[2026-02-12]** LocalStorage migration must be idempotent — LocalStorage key migrations must be idempotent and must not overwrite already-migrated values.
+
+**[2026-02-15]** Vercel ESM mode requires explicit config — Vercel can execute transpiled `api/all.js` as CommonJS unless package mode is explicit; keep `"type": "module"` in `package.json` for ESM imports.
+
+**[2026-02-20]** TS interfaces must match DB nullability — TypeScript interfaces in `api/all.ts` must match DB nullability. A `SMALLINT` column added without `NOT NULL` means the TS type must be `number | null`, not `number`.
+
+**[2026-02-21]** Kotlin rarity range min/max ordering — `rarityRange` in Kotlin backend did not reorder min/max, so `?rarity=1&minRarity=5` produced an empty range. TypeScript backend already had `Math.min`/`Math.max` normalization. Fix: apply `minOf`/`maxOf` in Kotlin to match.
+
+**[2026-02-24]** Unsanitized HTML from backend — Returning raw HTML changes from backend without updating frontend sanitizer breaks the safety contract.
+
+**[2026-02-24]** Verse delimiter breakage — Breaking the `" / "` delimiter contract causes line breaks to silently disappear in the frontend.
+
+## Romanian Morphology
+
+<!-- Format: **[YYYY-MM-DD]** Brief title — Explanation -->
+
+**[2026-02-19]** `-or` feminine has three subgroups — Adjective `-or` feminine forms have three distinct subgroups requiring specific rules: `-tor`→`-toare` (agentive), `-ior`→`-ioară` (Latin comparatives), `-șor`→`-șoară` (diminutives); neologisms (sonor, major) correctly use default `+ă`. A blanket `-or`→`-oare` rule is too broad.
+
+**[2026-02-19]** Diminutive `-el` uses `-ică` — Diminutive adjectives ending in `-el` (via sub-suffixes `-țel`, `-șel`, `-rel`) form feminine with `-ică`, not default `+ă`. Non-diminutive `-el` words (fidel, paralel) correctly use default.
+
+**[2026-02-19]** "negru" requires stem vowel alternation — Pre-existing edge case: "negru"→"neagră" requires a stem vowel alternation (e→ea) that simple suffix rules cannot handle; resolved via explicit `word == "negru"` special case. The alternation is lexical—"integru"→"integră" does NOT alternate—so pattern rules are unsafe.
+
+**[2026-02-19]** Feminine forms change syllable count — Feminine adjective forms can change syllable count (11 of 17 rules tested add +1), but `-ior`, `-iu`, `-ru`, invariants, and "negru" do NOT change. Providers using syllable-based selection (HaikuProvider) must query by the gender-specific form's syllable count via `feminine_syllables` column, paralleling the `articulated_syllables` pattern for nouns.
+
+**[2026-02-21]** Word-initial diphthong miscount — Word-initial 2-char diphthongs (ia, oa, ie, ea, ua) were skipped by the `if (i > 0)` guard in `replaceTongsWithChar`, inflating syllable counts by 1 for words like "iarbă" (returned 3 instead of 2). Triphthongs at position 0 were unaffected. Fix: collapse `i == 0` into the same branch as "after consonant".
+
+**[2026-02-21]** Vowel alternations are lexically conditioned — Romanian vowel alternations (`e→ea`, `o→oa`) in adjective feminization are **lexically conditioned** — each word must be special-cased. Added: "drept"→"dreaptă", "întreg"→"întreagă", "deșert"→"deșeartă", "mort"→"moartă". Counter-example: "integru"→"integră" does NOT alternate.
+
+## Data & Database
+
+<!-- Format: **[YYYY-MM-DD]** Brief title — Explanation -->
+
+**[2026-02-12]** `LC_ALL=C` for deterministic sorts — For deterministic shell joins/diffs by `word_id`, use `LC_ALL=C` when sorting.
+
+**[2026-02-20]** Migration V2 lacks `IF NOT EXISTS` — Migration V2 (`ALTER TABLE ADD COLUMN`, `CREATE INDEX`) lacks `IF NOT EXISTS` — re-running it on prod crashes. Always use `IF NOT EXISTS` for DDL in new migrations since there is no Flyway tracking on prod.
+
+**[2026-02-20]** New columns need backfill — Adding a column that the code queries in `WHERE` clauses or at startup (`initCounts`) is not enough — existing rows will have NULL and those queries return nothing. Either backfill in the migration SQL or run `loadDictionary` after migrating. HaikuProvider now has a fallback for this gap.
+
+**[2026-02-20]** `loadDictionary` TRUNCATE destroys rarity levels — `loadDictionary` TRUNCATE destroys externally-managed `rarity_level` values; the loader must never write `rarity_level` since it is managed by the external word-rarity-classifier project. The loader now backs up and restores rarity levels across reloads.
+
+**[2026-02-24]** Migration files are immutable — Updating migration files in-place instead of adding a new versioned migration causes Flyway validation failures.
+
+## Testing & Quality
+
+<!-- Format: **[YYYY-MM-DD]** Brief title — Explanation -->
+
+**[2026-02-07]** Testcontainers Ryuk failure with Colima — `./gradlew test` can fail locally when Testcontainers cannot start Ryuk with Colima Docker socket mount (`operation not supported`).
+
+**[2026-02-07]** Test reliability depends on Docker health — Full integration-test reliability depends on local Docker/Testcontainers health; use targeted subsets when container runtime is unstable.
+
+**[2026-02-24]** Test seed data constraints — Introducing new provider constraints that test seed data cannot satisfy causes test failures that look like code bugs.
+
+## Dependencies & External Services
+
+<!-- Format: **[YYYY-MM-DD]** Brief title — Explanation -->
+
+**[2026-02-12]** Dual-range slider pointer-events — Dual-range slider UX requires careful pointer-events handling for overlapping range inputs.
+
+**[2026-02-14]** Node v25 breaks npm ci — Local Node `v25` + npm `11` may break `npm ci` with `Exit handler never called!`; use Node `20` for stable JS fallback tests.
+
+**[2026-02-15]** Supabase lazy init required — Initializing Supabase at module import can hard-crash Vercel (`FUNCTION_INVOCATION_FAILED`) when `SUPABASE_URL` is malformed (e.g., JDBC URL); validate and lazily init inside request path.
+
+**[2026-02-15]** Generator misses are expected — `No valid prefix` / similar generator misses are normal at some rarity ranges; treat them as expected unsatisfiable outcomes, not error-level logs.
+
+## Process & Workflow
+
+<!-- Format: **[YYYY-MM-DD]** Brief title — Explanation -->
+
+---
+
+## Archive
+
+<!-- Format: **[YYYY-MM-DD] Archived [YYYY-MM-DD]** Title — Reason for archival -->
+
+**[2026-02-07] Archived [2026-02-24]** AGENTS.md should stay an operational index — Superseded by the new SETUP_AI_AGENT_CONFIG.md guide and restructured file system. AGENTS.md is now minimal non-discoverable constraints only; operational content lives in docs/.

--- a/SETUP_AI_AGENT_CONFIG.md
+++ b/SETUP_AI_AGENT_CONFIG.md
@@ -1,0 +1,394 @@
+# AI Agent Configuration Setup Guide
+
+> **Purpose:** This document serves two roles:
+> 1. **Setup guide** — step-by-step instructions for creating all config files from scratch
+> 2. **Maintenance protocol** — hand this document to an agent periodically to audit and clean all files, preserving only what's still useful
+>
+> Apply when: starting a new project, onboarding to an existing one, or running a periodic hygiene pass (weekly/monthly/yearly).
+
+---
+
+## Research Context — Why This Guide Exists
+
+This guide is informed by two key studies and extensive practitioner experience:
+
+- **[Evaluating AGENTS.md](https://arxiv.org/abs/2602.11988)** — Found that LLM-generated context files (via `/init`) **reduced** task success rates by ~3% on average while **increasing inference cost by 20%+**. Developer-provided files only improved performance by ~4% — marginal at best. Context files encouraged broader but less focused exploration.
+- **[SkillsBench](https://arxiv.org/abs/2602.12670)** — Found that **curated, focused skills** (2–3 modules) outperform comprehensive documentation. Self-generated skills provide no benefit on average. Smaller models with good skills can match larger models without them.
+
+**Core principle:** Help the model. Don't distract it. If the info is already in the codebase, it probably doesn't need to be in the config file.
+
+---
+
+## How the Files Work Together
+
+There are four file types, each with a distinct role. Understanding how they synchronize is essential — overlap between them is a bug, not a feature.
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        AGENT STARTS TASK                            │
+│                                                                     │
+│  1. Reads AGENTS.md (always in context — bootstrap only)            │
+│     → Non-discoverable constraints, legacy traps, file references   │
+│     → Tells agent: read LESSONS_LEARNED.md + which sub-agents exist │
+│                                                                     │
+│  2. Reads LESSONS_LEARNED.md (curated wisdom)                       │
+│     → Validated corrections and patterns from past sessions         │
+│     → This is where "the agent keeps doing X wrong" lives           │
+│                                                                     │
+│  3. If task is complex → delegates to sub-agent                     │
+│     → .claude/agents/architect.md, planner.md, etc.                 │
+│     → Focused procedural knowledge for specific domains             │
+│                                                                     │
+│  4. Does the work                                                   │
+│                                                                     │
+│  5. End of iteration:                                               │
+│     → ALWAYS appends to ITERATION_LOG.md (raw, what happened)       │
+│     → If reusable insight → adds to LESSONS_LEARNED.md              │
+│     → If something was surprising → flags to developer              │
+│                                                                     │
+│  Developer decides:                                                 │
+│     → Fix the codebase? (preferred)                                 │
+│     → Add to LESSONS_LEARNED.md? (if codebase fix isn't possible)   │
+│     → Add to AGENTS.md? (only if it's a non-discoverable constraint │
+│       that must be known BEFORE reading any other file)              │
+│     → Create a new sub-agent? (invoke agent-creator)                │
+│                                                                     │
+│  PERIODIC MAINTENANCE (weekly/monthly/yearly/new model):            │
+│     → Hand this document to an agent as a standalone task            │
+│     → Agent audits ALL files using the Maintenance Protocol          │
+│     → Stale entries archived, patterns promoted, overlaps removed    │
+│     → Files get leaner over time — never fatter                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### What lives where — the boundary rules
+
+| Question | → File |
+|----------|--------|
+| Can the model discover this from the codebase? | **Nowhere.** Don't write it down. |
+| Is this a constraint the model needs BEFORE it starts exploring? | **AGENTS.md** (e.g., "use pnpm not npm", "dev server already running") |
+| Is this a correction for a repeated mistake? | **LESSONS_LEARNED.md** (not AGENTS.md) |
+| Is this a raw observation from a single session? | **ITERATION_LOG.md** |
+| Is this focused procedural knowledge for a recurring task domain? | **Sub-agent** in `.claude/agents/` |
+| Does something in the codebase keep confusing agents? | **Fix the codebase first.** Then LESSONS_LEARNED if needed. |
+
+### Promotion flow
+
+```
+Observation (single session)
+  → ITERATION_LOG.md (always)
+
+Same issue appears 2+ times in ITERATION_LOG
+  → Promote to LESSONS_LEARNED.md
+
+Lesson becomes obsolete (dependency removed, API changed, model improved)
+  → Move to Archive section in LESSONS_LEARNED.md (never delete)
+
+New recurring task domain emerges
+  → Invoke agent-creator → new sub-agent in .claude/agents/
+
+New model release
+  → Delete AGENTS.md entirely. Test. Re-add only what's still needed.
+  → Review LESSONS_LEARNED.md — many entries may be obsolete.
+
+Periodic maintenance (weekly/monthly/yearly)
+  → Hand this document to an agent: "Run the Periodic Maintenance Protocol"
+  → Agent audits ALL files, removes stale info, promotes unhandled patterns
+  → Agent produces a maintenance report for developer review
+  → Files get leaner over time, never fatter
+```
+
+---
+
+## File Structure Overview
+
+After applying this guide, your project root should contain:
+
+```
+project-root/
+├── AGENTS.md                 # Bootstrap context (minimal, non-discoverable constraints only)
+├── CLAUDE.md                 # Redirect → AGENTS.md
+├── LESSONS_LEARNED.md        # Curated corrections and validated wisdom
+├── ITERATION_LOG.md          # Append-only session journal
+└── .claude/
+    └── agents/               # Specialized sub-agents
+        ├── architect.md      # System design, ADRs
+        ├── planner.md        # Multi-step implementation plans
+        ├── agent-creator.md  # Meta-agent: creates new specialized agents
+        └── ux-expert.md      # UI/UX decisions (frontend projects only)
+```
+
+---
+
+## Step 1: Create `CLAUDE.md` (Redirect Only)
+
+Create `CLAUDE.md` in the project root with **exactly** this content:
+
+```markdown
+Read AGENTS.md
+```
+
+Nothing else. This ensures any tool that looks for `CLAUDE.md` is immediately redirected to the canonical file.
+
+---
+
+## Step 2: Create `AGENTS.md` (Bootstrap Only)
+
+This file is always in the agent's context window. Every token here costs attention on every single request. Therefore: **only include things the model needs to know BEFORE it starts exploring the codebase.**
+
+### What DOES NOT belong in AGENTS.md
+
+These are things the model discovers on its own. Including them wastes context, biases toward stale info, and increases cost by 20%+:
+
+- ❌ Project architecture overviews (the model reads your file tree, imports, configs)
+- ❌ Dependency lists (the model reads `package.json`, `pom.xml`, `requirements.txt`)
+- ❌ Available scripts/commands (the model reads `package.json` scripts, `Makefile`)
+- ❌ Folder structure descriptions (the model uses `find`, `ls`, `rg` to explore)
+- ❌ Code style rules the linter already enforces
+- ❌ General best practices the model already knows (SOLID, DRY, etc.)
+- ❌ Anything produced by `/init` — delete it
+- ❌ Corrections for repeated mistakes — these belong in `LESSONS_LEARNED.md`
+
+### What DOES belong in AGENTS.md
+
+Only things the model **cannot discover** and **needs before starting work**:
+
+- ✅ Non-obvious tooling constraints (e.g., "Use pnpm, not npm — workspaces break otherwise")
+- ✅ Environment assumptions (e.g., "Dev server is always already running — do not start it")
+- ✅ Legacy traps that would mislead on first encounter (e.g., "TRPC routes in `/api/legacy/` are deprecated — use Convex")
+- ✅ References to LESSONS_LEARNED.md, ITERATION_LOG.md, and sub-agents (so the agent knows the system exists)
+
+### Maintenance Philosophy
+
+AGENTS.md should **shrink over time**, not grow:
+
+- **Monthly audit:** Delete entries for behaviors the model no longer exhibits.
+- **New model release:** Delete AGENTS.md entirely. Test. Re-add only what's still needed.
+- **Never use `/init`:** Auto-generated content is worse than no content (−3% success, +20% cost).
+- **Prefer fixing the codebase** over adding entries. Better tests, clearer naming, proper linting > more config text.
+
+---
+
+## Step 3: Create Sub-Agents in `.claude/agents/`
+
+Sub-agents provide focused procedural knowledge for specific domains. Per SkillsBench: curated, focused skills (2–3 modules) raise pass rates by 16.2pp on average. Self-generated skills provide no benefit.
+
+See existing agents in `.claude/agents/` for structure and conventions.
+
+### Agent Design Rules
+
+1. **Focus (2–3 Modules Maximum)** — An agent covering everything helps with nothing.
+2. **Mandatory Structure** — Each agent must have: frontmatter (name, description, tools, model), When to Activate (3+ triggers), Role, Output Format (concrete templates), Principles (3-5 actionable items).
+3. **Anti-Patterns** — Don't include discoverable info, don't duplicate AGENTS.md/LESSONS_LEARNED, don't create overlapping agents, keep under 100 lines.
+4. **Registration** — After creating an agent, update the Sub-Agents table in `AGENTS.md`.
+
+---
+
+## Step 4: Create `LESSONS_LEARNED.md`
+
+This is the curated knowledge base — validated corrections and reusable insights.
+This is where "the agent keeps doing X wrong → do Y instead" lives.
+NOT in AGENTS.md. Here.
+
+Categories: Architecture & Design Decisions, Code Patterns & Pitfalls, Testing & Quality, Performance & Infrastructure, Dependencies & External Services, Process & Workflow, plus an Archive section at bottom.
+
+Format: `**[YYYY-MM-DD]** Brief title — Explanation`
+
+---
+
+## Step 5: Create `ITERATION_LOG.md`
+
+Raw, append-only journal. The source of truth for what happened. Patterns here get promoted to LESSONS_LEARNED.
+
+Entry format:
+```
+### [YYYY-MM-DD] Brief Description
+**Context:** What was the goal
+**What happened:** Key actions, decisions
+**Outcome:** Success / partial / failure
+**Insight:** (optional) What would you tell the next agent?
+**Promoted to Lessons Learned:** Yes / No
+```
+
+---
+
+## Step 6: Git Configuration
+
+```bash
+git add AGENTS.md CLAUDE.md LESSONS_LEARNED.md ITERATION_LOG.md .claude/agents/
+git commit -m "chore: add AI agent configuration and memory system"
+```
+
+---
+
+## Verification Checklist
+
+- [ ] `CLAUDE.md` exists and contains only `Read AGENTS.md`
+- [ ] `AGENTS.md` exists, is minimal, contains NO `/init` content and NO corrections (those are in LESSONS_LEARNED)
+- [ ] `AGENTS.md` references LESSONS_LEARNED.md, ITERATION_LOG.md, and sub-agents
+- [ ] Sub-agents exist in `.claude/agents/` with proper frontmatter
+- [ ] `LESSONS_LEARNED.md` exists with categorized sections and Archive
+- [ ] `ITERATION_LOG.md` exists with entry format template
+- [ ] All files tracked in git
+- [ ] No file contains architecture overviews, folder structures, or dependency lists
+- [ ] AGENTS.md and LESSONS_LEARNED.md have zero content overlap
+
+---
+
+## Quick Reference: Decision Flowchart
+
+```
+Agent keeps making the same mistake?
+  └─ Can I fix the codebase to prevent it?
+      ├─ YES → Fix the code (better tests, clearer naming, linting)
+      └─ NO  → Log in ITERATION_LOG → if 2+ times → promote to LESSONS_LEARNED
+
+Agent needs to know something BEFORE it starts exploring?
+  └─ Is it discoverable from the codebase?
+      ├─ YES → Don't add it anywhere
+      └─ NO  → AGENTS.md "Constraints" section (keep it one line)
+
+Complex multi-step task?
+  └─ Invoke planner agent BEFORE writing code
+
+Architecture decision?
+  └─ Invoke architect agent → record decision as ADR
+
+Frontend component design?
+  └─ Invoke ux-expert agent
+
+Recurring task domain with no specialized agent?
+  └─ Invoke agent-creator → it will design one following SkillsBench constraints
+
+New model release?
+  └─ Delete AGENTS.md. Test. Re-add only what breaks.
+  └─ Review LESSONS_LEARNED — archive anything the new model handles correctly.
+
+AGENTS.md getting long?
+  └─ Something is wrong. It should shrink over time, not grow.
+  └─ Are corrections in AGENTS.md? Move them to LESSONS_LEARNED.
+  └─ Is discoverable info in AGENTS.md? Delete it.
+
+Time for maintenance? (weekly/monthly/yearly/new model)
+  └─ Hand this entire document to an agent with:
+     "Run the Periodic Maintenance Protocol on this project."
+  └─ Review the maintenance report. Approve or adjust flagged items.
+```
+
+---
+
+## Periodic Maintenance Protocol
+
+This section is designed as a **standalone task**. Hand this entire document to an agent with the instruction: *"Run the maintenance protocol on this project."* The agent should be able to audit and clean all config files without further guidance.
+
+### When to Run
+
+| Frequency | Trigger |
+|-----------|---------|
+| **Weekly** (active projects) | High iteration velocity, many ITERATION_LOG entries accumulating |
+| **Monthly** (steady projects) | Default cadence for most projects |
+| **Per model release** | New model may handle things differently — major cleanup opportunity |
+| **Yearly** (dormant projects) | Before resuming work after a long pause |
+
+### The Audit — Step by Step
+
+#### Phase 1: Audit AGENTS.md
+
+Goal: AGENTS.md should be **as small as possible**. Every line must earn its place.
+
+```
+For each entry in AGENTS.md "Constraints":
+  1. Try to discover this information from the codebase alone
+  2. If discoverable → REMOVE from AGENTS.md
+  3. If not discoverable → KEEP, but check if it's still accurate
+  4. If inaccurate → FIX or REMOVE
+
+For each entry in AGENTS.md "Legacy & Deprecated":
+  1. Check if the legacy code/routes/files still exist
+  2. If removed → REMOVE from AGENTS.md
+  3. If still present → KEEP
+
+Check: Does AGENTS.md contain any corrections/patterns?
+  → If yes, MOVE them to LESSONS_LEARNED.md
+
+Check: Does AGENTS.md sub-agents table match actual files in .claude/agents/?
+  → Remove rows for agents that no longer exist
+  → Add rows for agents that exist but aren't listed
+```
+
+#### Phase 2: Audit LESSONS_LEARNED.md
+
+Goal: Every lesson must be **still relevant** and **not duplicated** elsewhere.
+
+```
+For each lesson:
+  1. Still accurate? → If obsolete → MOVE to Archive with date and reason
+  2. Now enforced by codebase? → If enforced → MOVE to Archive
+  3. Duplicated in AGENTS.md? → REMOVE from AGENTS.md
+  4. Too verbose? → CONDENSE
+  5. Duplicates another lesson? → MERGE
+```
+
+#### Phase 3: Audit ITERATION_LOG.md
+
+Goal: Patterns should be **promoted**.
+
+```
+Scan entries since last maintenance:
+  1. Repeated issues (2+ entries) not yet in LESSONS_LEARNED → PROMOTE
+  2. Valuable unpromoted insights → Propose promotion
+
+Over 200 entries? → Archive older entries (>6 months) to ITERATION_LOG_ARCHIVE.md
+```
+
+#### Phase 4: Audit Sub-Agents (.claude/agents/)
+
+```
+For each agent:
+  1. Still being invoked? → If unused 3+ months → FLAG for review
+  2. References stale tools/patterns? → UPDATE or REMOVE
+  3. Over 100 lines? → SPLIT or CONDENSE
+  4. Overlaps another agent? → MERGE or clarify boundaries
+
+Recurring tasks without agent coverage? → Propose new agent
+```
+
+#### Phase 5: Cross-File Consistency Check
+
+```
+Check for duplicated content across files → Keep in one place only
+Check all file path references → Still valid?
+Check AGENTS.md sub-agents table → Matches .claude/agents/ directory?
+```
+
+### Maintenance Report Format
+
+```markdown
+# Maintenance Report — [YYYY-MM-DD]
+
+## Summary
+- AGENTS.md: [N] entries removed, [N] kept, [N] corrected
+- LESSONS_LEARNED.md: [N] archived, [N] condensed, [N] merged, [N] kept
+- ITERATION_LOG.md: [N] patterns promoted, [N] entries since last maintenance
+- Sub-agents: [N] updated, [N] flagged for review, [N] unchanged
+
+## Changes Made
+<!-- List each change with brief rationale -->
+
+## Flagged for Developer Decision
+<!-- Things the agent couldn't decide autonomously -->
+
+## Health Score
+- AGENTS.md size: [N] lines (target: <30)
+- LESSONS_LEARNED.md active entries: [N] (target: <50 per category)
+- ITERATION_LOG.md unprocessed entries: [N] (target: 0 patterns unhandled)
+- Sub-agents count: [N] (warning if >8)
+- Cross-file duplicates found: [N] (target: 0)
+```
+
+---
+
+## References
+
+- Röttger et al. (2026). *Evaluating AGENTS.md: Are Repository-Level Context Files Helpful for Coding Agents?* [arxiv.org/abs/2602.11988](https://arxiv.org/abs/2602.11988)
+- Li et al. (2026). *SkillsBench: Benchmarking How Well Agent Skills Work Across Diverse Tasks.* [arxiv.org/abs/2602.12670](https://arxiv.org/abs/2602.12670)


### PR DESCRIPTION
Slim AGENTS.md from 145 to 51 lines (non-discoverable constraints only).
Categorize LESSONS_LEARNED.md into 7 sections + Archive. Create
ITERATION_LOG.md for session journaling. Add 4 new sub-agents (architect,
planner, agent-creator, ux-expert). Remove inapplicable React/Next.js
references from code-reviewer, code-simplifier, and refactor-cleaner.
Embed "How To" recipes into planner agent. Save setup guide as
SETUP_AI_AGENT_CONFIG.md for periodic maintenance.

https://claude.ai/code/session_013snTxf8rFuDMxqDF5EuqyQ