### PR TITLE
Add cache control headers to API responses

### DIFF
--- a/api/all.ts
+++ b/api/all.ts
@@ -688,7 +688,6 @@ export default async function handler(req: VercelRequestLike, res: VercelRespons
   res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
   res.setHeader("Access-Control-Allow-Headers", "Content-Type");
   res.setHeader("Access-Control-Max-Age", "86400");
-  res.setHeader("Cache-Control", "max-age=180");
 
   if (req.method === "OPTIONS") return res.status(204).end();
   if (req.method !== "GET") return res.status(405).json({ error: "Method Not Allowed" });
@@ -726,6 +725,7 @@ export default async function handler(req: VercelRequestLike, res: VercelRespons
       safe(() => genMirror(minR, maxR, cache)),
     ]);
 
+  res.setHeader("Cache-Control", "max-age=180");
   return res.status(200).json({
     haiku,
     distih,

--- a/api/all.ts
+++ b/api/all.ts
@@ -688,6 +688,7 @@ export default async function handler(req: VercelRequestLike, res: VercelRespons
   res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
   res.setHeader("Access-Control-Allow-Headers", "Content-Type");
   res.setHeader("Access-Control-Max-Age", "86400");
+  res.setHeader("Cache-Control", "max-age=180");
 
   if (req.method === "OPTIONS") return res.status(204).end();
   if (req.method !== "GET") return res.status(405).json({ error: "Method Not Allowed" });

--- a/src/main/kotlin/scrabble/phrases/CacheControlFilter.kt
+++ b/src/main/kotlin/scrabble/phrases/CacheControlFilter.kt
@@ -10,7 +10,7 @@ class CacheControlFilter : ContainerResponseFilter {
 
     override fun filter(requestContext: ContainerRequestContext, responseContext: ContainerResponseContext) {
         val path = requestContext.uriInfo.path
-        if (path.startsWith("api/")) {
+        if (path.startsWith("api/") && responseContext.status in 200..299) {
             responseContext.headers.putSingle("Cache-Control", "max-age=$MAX_AGE_SECONDS")
         }
     }

--- a/src/main/kotlin/scrabble/phrases/CacheControlFilter.kt
+++ b/src/main/kotlin/scrabble/phrases/CacheControlFilter.kt
@@ -1,0 +1,21 @@
+package scrabble.phrases
+
+import jakarta.ws.rs.container.ContainerRequestContext
+import jakarta.ws.rs.container.ContainerResponseContext
+import jakarta.ws.rs.container.ContainerResponseFilter
+import jakarta.ws.rs.ext.Provider
+
+@Provider
+class CacheControlFilter : ContainerResponseFilter {
+
+    override fun filter(requestContext: ContainerRequestContext, responseContext: ContainerResponseContext) {
+        val path = requestContext.uriInfo.path
+        if (path.startsWith("api/")) {
+            responseContext.headers.putSingle("Cache-Control", "max-age=$MAX_AGE_SECONDS")
+        }
+    }
+
+    companion object {
+        private const val MAX_AGE_SECONDS = 180
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds HTTP cache control headers to API responses to improve performance and reduce unnecessary requests. Cache headers are configured with a 180-second (3-minute) max-age for successful API responses.

## Key Changes
- **Backend (Kotlin)**: Added `CacheControlFilter` JAX-RS response filter that automatically injects `Cache-Control: max-age=180` headers for all successful API responses (status 200-299)
- **Frontend (Vercel)**: Added explicit `Cache-Control` header to the main API handler response with the same 180-second max-age value

## Implementation Details
- The `CacheControlFilter` is a JAX-RS `@Provider` that intercepts all responses and conditionally applies caching headers to paths starting with `api/` that return successful status codes
- The max-age value (180 seconds) is defined as a constant to ensure consistency across both backend and frontend implementations
- This approach provides both server-side (Kotlin) and client-side (Vercel) cache control, ensuring consistent caching behavior across the application

https://claude.ai/code/session_01WHeEdFu4Gey4bYJCZpaoDd