### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -1,5 +1,8 @@
 name: Database Operations
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/fabian20ro/propozitii-nostime/security/code-scanning/3](https://github.com/fabian20ro/propozitii-nostime/security/code-scanning/3)

In general, this should be fixed by explicitly specifying a `permissions:` block that grants only the minimal required scopes to the `GITHUB_TOKEN`. Because neither job writes to GitHub resources, a read-only permission on repository contents is sufficient (`contents: read`). Defining this once at the workflow root will apply to all jobs that don’t override it.

The best minimal fix without changing existing functionality is to add a root-level `permissions:` section right under the `name:` line, before the `on:` block, and set it to `contents: read`. This documents the expected token scope, keeps the current behavior for any repo whose default token is already read-only, and constrains the token appropriately in repos where defaults are broader. No other steps or lines need to change.

Concretely, in `.github/workflows/database.yml`, between line 1 (`name: Database Operations`) and line 3 (`on:`), insert:

```yaml
permissions:
  contents: read
```

No new imports or external tools are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
