### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -26,6 +26,9 @@ on:
       - 'vercel.json'
       - '.github/workflows/backend.yml'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/fabian20ro/propozitii-nostime/security/code-scanning/2](https://github.com/fabian20ro/propozitii-nostime/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/backend.yml` at the workflow root (top-level, alongside `name` and `on`) so all jobs inherit least-privilege by default.

Best single fix (without changing behavior): add:

- `contents: read` (minimum recommended, needed for checkout and repository reads)

Place it after the `on:` section (or before `jobs:`) so it applies to `build` and any future jobs unless overridden. No imports/dependencies/methods are needed; this is a YAML config-only change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
