### PR TITLE
Centralize Dexonline anchor attributes and add WordRepository debug selection logs

### DIFF
--- a/api/__tests__/all.test.ts
+++ b/api/__tests__/all.test.ts
@@ -12,6 +12,9 @@ import {
   resolveSupabaseInit,
   validateSupabaseUrl,
   DEXONLINE_URL,
+  DEXONLINE_ANCHOR_ATTRS,
+  DEXONLINE_ANCHOR_TARGET,
+  DEXONLINE_ANCHOR_REL,
   type Adjective,
 } from "../all";
 
@@ -191,9 +194,13 @@ describe("parity contract", () => {
 
   it("anchors include target=_blank, rel=noopener, data-word", () => {
     const result = addDexLinks("test");
-    expect(result).toMatch(/target="_blank"/);
-    expect(result).toMatch(/rel="noopener"/);
+    expect(result).toMatch(new RegExp(`target="${DEXONLINE_ANCHOR_TARGET}"`));
+    expect(result).toMatch(new RegExp(`rel="${DEXONLINE_ANCHOR_REL}"`));
     expect(result).toMatch(/data-word="test"/);
+  });
+
+  it("anchor attribute contract stays explicit", () => {
+    expect([...DEXONLINE_ANCHOR_ATTRS]).toEqual(["href", "target", "rel", "data-word"]);
   });
 });
 

--- a/api/all.ts
+++ b/api/all.ts
@@ -150,6 +150,9 @@ function withTimeout<T>(promise: Promise<T>, fallback: T, ms: number): Promise<T
 }
 
 export const DEXONLINE_URL = "https://dexonline.ro/definitie/";
+export const DEXONLINE_ANCHOR_ATTRS = ["href", "target", "rel", "data-word"] as const;
+export const DEXONLINE_ANCHOR_TARGET = "_blank";
+export const DEXONLINE_ANCHOR_REL = "noopener";
 const UNSATISFIABLE =
   "Nu există suficiente cuvinte pentru nivelul de raritate ales.";
 
@@ -534,7 +537,7 @@ export function escapeHtml(text: string): string {
 export function addDexLinks(sentence: string): string {
   return sentence.replace(/\p{L}+/gu, (w) => {
     const encoded = encodeURIComponent(w.toLowerCase());
-    return `<a href="${DEXONLINE_URL}${encoded}" target="_blank" rel="noopener" data-word="${encoded}">${escapeHtml(w)}</a>`;
+    return `<a href="${DEXONLINE_URL}${encoded}" target="${DEXONLINE_ANCHOR_TARGET}" rel="${DEXONLINE_ANCHOR_REL}" data-word="${encoded}">${escapeHtml(w)}</a>`;
   });
 }
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -79,6 +79,7 @@ curl "https://propozitii-nostime.vercel.app/api/all?minRarity=1&rarity=2"
 - Backend logs: Render dashboard.
 - Default log level: `INFO`.
 - Package debug level: `scrabble.phrases` set to `DEBUG`.
+- Generator diagnostics (debug): `WordRepository` now logs selection strategy (`count_offset`, `order_by_random_not_in`, rhyme-group cache/DB path), rarity range, and exclude-set size when `DEBUG` is enabled for `scrabble.phrases`.
 
 ## Common Incidents
 

--- a/src/main/kotlin/scrabble/phrases/decorators/DexonlineLinkAdder.kt
+++ b/src/main/kotlin/scrabble/phrases/decorators/DexonlineLinkAdder.kt
@@ -7,7 +7,10 @@ import java.nio.charset.StandardCharsets
 class DexonlineLinkAdder(private val provider: ISentenceProvider) : ISentenceProvider {
 
     companion object {
-        private const val DEXONLINE_URL = "https://dexonline.ro/definitie/"
+        const val DEXONLINE_URL = "https://dexonline.ro/definitie/"
+        const val LINK_TARGET = "_blank"
+        const val LINK_REL = "noopener"
+        const val ATTR_DATA_WORD = "data-word"
     }
 
     override fun getSentence(): String =
@@ -17,7 +20,7 @@ class DexonlineLinkAdder(private val provider: ISentenceProvider) : ISentencePro
         val encodedWord = URLEncoder.encode(word.lowercase(), StandardCharsets.UTF_8)
         val url = "$DEXONLINE_URL$encodedWord"
         val escapedWord = escapeHtml(word)
-        return """<a href="$url" target="_blank" rel="noopener" data-word="$encodedWord">$escapedWord</a>"""
+        return """<a href="$url" target="$LINK_TARGET" rel="$LINK_REL" $ATTR_DATA_WORD="$encodedWord">$escapedWord</a>"""
     }
 
     private fun escapeHtml(text: String): String = text

--- a/src/main/kotlin/scrabble/phrases/repository/WordRepository.kt
+++ b/src/main/kotlin/scrabble/phrases/repository/WordRepository.kt
@@ -4,6 +4,7 @@ import io.agroal.api.AgroalDataSource
 import io.quarkus.runtime.Startup
 import jakarta.annotation.PostConstruct
 import jakarta.enterprise.context.ApplicationScoped
+import org.jboss.logging.Logger
 import scrabble.phrases.words.Adjective
 import scrabble.phrases.words.Noun
 import scrabble.phrases.words.NounGender
@@ -13,6 +14,7 @@ import java.util.concurrent.ThreadLocalRandom
 @Startup
 @ApplicationScoped
 class WordRepository(private val dataSource: AgroalDataSource) {
+    private val log: Logger = Logger.getLogger(WordRepository::class.java)
 
     private var countsByTypeMaxRarity: Map<Pair<String, Int>, Int> = emptyMap()
     private var countsByTypeSyllablesMaxRarity: Map<Triple<String, Int, Int>, Int> = emptyMap()
@@ -157,10 +159,16 @@ class WordRepository(private val dataSource: AgroalDataSource) {
     private fun rarityDesc(minRarity: Int, maxRarity: Int): String =
         if (minRarity <= 1) "<= $maxRarity" else "between $minRarity and $maxRarity"
 
+    private fun debugSelection(strategy: String, type: String, minRarity: Int, maxRarity: Int, extras: String = "") {
+        if (!log.isDebugEnabled) return
+        log.debug("selection strategy=$strategy type=$type rarity=${rarityDesc(minRarity, maxRarity)} $extras")
+    }
+
     fun getRandomNoun(minRarity: Int = 1, maxRarity: Int = DEFAULT_MAX_RARITY, exclude: Set<String> = emptySet()): Noun {
         val min = clampRarity(minRarity)
         val max = clampRarity(maxRarity)
         if (exclude.isNotEmpty()) {
+            debugSelection("order_by_random_not_in", "N", min, max, "exclude=${exclude.size}")
             val notIn = notInClause(exclude.size)
             return queryNoun(
                 "SELECT word, gender, syllables, rhyme, articulated FROM words WHERE type='N' AND rarity_level BETWEEN ? AND ? AND word NOT IN ($notIn) ORDER BY RANDOM() LIMIT 1",
@@ -168,6 +176,7 @@ class WordRepository(private val dataSource: AgroalDataSource) {
             ) ?: throw IllegalStateException("No nouns found in database for rarity ${rarityDesc(min, max)}")
         }
         val count = rangeCount(countsByTypeMaxRarity, "N", min, max)
+        debugSelection("count_offset", "N", min, max, "count=$count exclude=0")
         if (count == 0) throw IllegalStateException("No nouns found in database for rarity ${rarityDesc(min, max)}")
         return queryNoun(
             "SELECT word, gender, syllables, rhyme, articulated FROM words WHERE type='N' AND rarity_level BETWEEN ? AND ? LIMIT 1 OFFSET ?",
@@ -213,6 +222,7 @@ class WordRepository(private val dataSource: AgroalDataSource) {
 
         val count = rangeCountTriple(countsByTypeArticulatedSyllablesMaxRarity, "N", articulatedSyllables, min, max)
         if (count == 0) return null
+        debugSelection("count_offset_dim", "N", min, max, "dim=articulated_syllables value=$articulatedSyllables count=$count")
         return queryNoun(
             "SELECT word, gender, syllables, rhyme, articulated FROM words WHERE type='N' AND articulated_syllables=? AND rarity_level BETWEEN ? AND ? LIMIT 1 OFFSET ?",
             articulatedSyllables,
@@ -226,6 +236,7 @@ class WordRepository(private val dataSource: AgroalDataSource) {
         val min = clampRarity(minRarity)
         val max = clampRarity(maxRarity)
         if (exclude.isNotEmpty()) {
+            debugSelection("order_by_random_not_in", "V", min, max, "exclude=${exclude.size}")
             val notIn = notInClause(exclude.size)
             return queryAdjective(
                 "SELECT word, syllables, rhyme, feminine, feminine_syllables FROM words WHERE type='A' AND rarity_level BETWEEN ? AND ? AND word NOT IN ($notIn) ORDER BY RANDOM() LIMIT 1",
@@ -281,6 +292,7 @@ class WordRepository(private val dataSource: AgroalDataSource) {
             ) ?: throw IllegalStateException("No verbs found in database for rarity ${rarityDesc(min, max)}")
         }
         val count = rangeCount(countsByTypeMaxRarity, "V", min, max)
+        debugSelection("count_offset", "V", min, max, "count=$count exclude=0")
         if (count == 0) throw IllegalStateException("No verbs found in database for rarity ${rarityDesc(min, max)}")
         return queryVerb(
             "SELECT word, syllables, rhyme FROM words WHERE type='V' AND rarity_level BETWEEN ? AND ? LIMIT 1 OFFSET ?",
@@ -333,10 +345,12 @@ class WordRepository(private val dataSource: AgroalDataSource) {
                 else -> null
             }
             if (cached != null && cached.size >= 2) {
+                debugSelection("cached_rhyme_groups", type, min, max, "minCount=$minCount cached=${cached.size}")
                 val shuffled = cached.shuffled(ThreadLocalRandom.current())
                 return Pair(shuffled[0], shuffled[1])
             }
         }
+        debugSelection("db_rhyme_groups", type, min, max, "minCount=$minCount")
         return findTwoRhymeGroupsFromDb(type, minCount, min, max)
     }
 

--- a/src/test/kotlin/scrabble/phrases/decorators/DecoratorTest.kt
+++ b/src/test/kotlin/scrabble/phrases/decorators/DecoratorTest.kt
@@ -1,6 +1,8 @@
 package scrabble.phrases.decorators
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import scrabble.phrases.providers.ISentenceProvider
 
@@ -58,5 +60,17 @@ class DecoratorTest {
         val baseProvider = ISentenceProvider { "line one / line two / line three" }
         val breaker = HtmlVerseBreaker(baseProvider)
         assertEquals("line one<br/>line two<br/>line three", breaker.getSentence())
+    }
+
+    @Test
+    fun shouldKeepAnchorContract() {
+        val baseProvider = ISentenceProvider { "Masă" }
+        val result = DexonlineLinkAdder(baseProvider).getSentence()
+
+        assertTrue(result.contains("""href="${DexonlineLinkAdder.DEXONLINE_URL}mas%C4%83""""))
+        assertTrue(result.contains("""target="${DexonlineLinkAdder.LINK_TARGET}""""))
+        assertTrue(result.contains("""rel="${DexonlineLinkAdder.LINK_REL}""""))
+        assertTrue(result.contains("""${DexonlineLinkAdder.ATTR_DATA_WORD}="mas%C4%83""""))
+        assertFalse(result.contains("onclick="))
     }
 }


### PR DESCRIPTION
### Motivation
- Centralize and make explicit the HTML anchor attribute contract used for Dexonline links so both TypeScript and Kotlin decorators emit the same attributes. 
- Replace hard-coded `target`/`rel` values with named constants to reduce duplication and make the contract verifiable in tests. 
- Add debug diagnostics to `WordRepository` to surface generator selection strategy and parameters when `DEBUG` is enabled for easier investigation of selection/rarity issues. 

### Description
- Added `DEXONLINE_ANCHOR_ATTRS`, `DEXONLINE_ANCHOR_TARGET`, and `DEXONLINE_ANCHOR_REL` to `api/all.ts` and updated `addDexLinks` to use those constants instead of hard-coded strings. 
- Updated TypeScript tests in `api/__tests__/all.test.ts` to assert the anchor attribute contract and to use the new constants when matching `target`/`rel`. 
- Updated Kotlin `DexonlineLinkAdder` to use `LINK_TARGET`, `LINK_REL`, and `ATTR_DATA_WORD` constants and added a unit test `shouldKeepAnchorContract` in `DecoratorTest.kt` to verify encoding and absence of unexpected attributes. 
- Added debug logging support in `WordRepository` by introducing a `Logger`, a `debugSelection` helper, and calls to log selection strategy, rarity range, and extras at key selection paths, and documented the behavior in `docs/RUNBOOK.md`. 

### Testing
- Ran the TypeScript unit test suite with `vitest` for `api/__tests__/all.test.ts`, which passed. 
- Ran the JVM unit tests with `./gradlew test`, which passed and includes the new `DecoratorTest` assertions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f995e91c98832290d4f5287d7a4f18)